### PR TITLE
fix: filter classes on Compiler pass

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zhortein/symfony-toolbox-bundle",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "symfony": {
     "controllers": {
       "datatable": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "description": "This bundle is dedicated to Symfony applications and provide useful tools for your app.",
   "homepage": "https://www.david-renard.fr",
   "license": "GPL-3.0-or-later",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "authors": [
     {
       "name": "David Renard",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symfony-toolbox-bundle",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Symfony Toolbox Bundle",
   "author": "David RENARD",
   "license": "GPL-3.0-or-later",

--- a/src/DependencyInjection/SymfonyToolboxCompilerPass.php
+++ b/src/DependencyInjection/SymfonyToolboxCompilerPass.php
@@ -42,7 +42,7 @@ class SymfonyToolboxCompilerPass implements CompilerPassInterface
         foreach ($container->getDefinitions() as $definition) {
             $class = $definition->getClass();
 
-            if (!$class || !class_exists($class) || str_contains($class, 'class@anonymous')) {
+            if (!$class || str_contains($class, 'class@anonymous') || !str_starts_with($class, 'Zhortein\\') || !str_starts_with($class, 'App\\') || !class_exists($class)) {
                 continue;
             }
 

--- a/tests/Unit/Service/BusinessDateTimeTest.php
+++ b/tests/Unit/Service/BusinessDateTimeTest.php
@@ -169,7 +169,7 @@ class BusinessDateTimeTest extends TestCase
 
     public function testAddHoliday(): void
     {
-        $date = new \DateTime('2024-12-26');
+        $date = new \DateTime('2025-12-26');
         $this->businessDateTime->addHoliday($date);
         $this->assertTrue($this->businessDateTime->isHoliday($date, 'FR'));
     }


### PR DESCRIPTION
Filter classes on Compiler pass to avoid loaded deprecated or non existent classes from other bundles